### PR TITLE
chore: update POM and CI config for Sonatype Central Portal migration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,11 +30,15 @@ jobs:
           gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
 
       - name: Deploy SNAPSHOT / Release
-        uses: camunda-community-hub/community-action-maven-release@v1
+        uses: camunda-community-hub/community-action-maven-release@v2
         with:
           release-version: ${{ github.event.release.tag_name }}
           nexus-usr: ${{ secrets.NEXUS_USR }}
           nexus-psw: ${{ secrets.NEXUS_PSW }}
+          sonatype-central-portal-usr: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_CP_USR }}
+          sonatype-central-portal-psw: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_CP_PSW }}
+          # maven-usr and maven-psw are deprecated; they are required only for publishing to the legacy OSS Sonatype repository.
+          # Once the org.camunda namespace is fully migrated to the Sonatype Central Portal, these can be safely removed.
           maven-usr: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_OSS_USR }}
           maven-psw: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_OSS_PSW }}
           maven-additional-options: -U

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.camunda.community</groupId>
         <artifactId>community-hub-release-parent</artifactId>
-        <version>1.4.2</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>community-hub-extension-example</artifactId>


### PR DESCRIPTION
This PR demonstrates the required changes needed in community hub projects to prepare for the migration to the Sonatype Central Portal:
- upgrade to the latest community hub parent POM (2.0.0)
- update the `camunda-community-hub/community-action-maven-release` GitHub Action to `@v2`, with the new Sonatype Central Portal credentials

Although this demo project is currently deployed under the `org.camunda` namespace which has not yet been migrated to the Central Portal, this PR is safe to merge ahead of time. It will:
- continue using OSSRH until the namespace is migrated
- seamlessly switch to the Central Portal once the migration is complete
